### PR TITLE
M3 – Watchers & Remote Change: integrazione Persistent History + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ GraphCK è un fork moderno e aggiornato della libreria [CosmicMind/Graph](https:
 
 ---
 
-## ✅ Stato attuale (Milestone M2 – CloudKit Container)
+## ✅ Milestone M3 – Watchers & Remote Change
 
 - Refactor modello (M1) completato: rimosso `Transformable` generico, introdotto `ValueTransformer` sicuro
-- Sostituito `NSPersistentContainer` con `NSPersistentCloudKitContainer`
+- Supporto `NSPersistentCloudKitContainer` (M2)
 - Store SQLite rinominato automaticamente in `GraphCK_<name>.sqlite`
 - Opzioni abilitate: `NSPersistentHistoryTrackingKey`, `NSPersistentStoreRemoteChangeNotificationPostOptionKey`
-- Delegate `GraphCloudStatusDelegate` per notificare disponibilità iCloud (funziona anche senza entitlements, fallback locale)
-- Fallback automatico su store locale se iCloud non disponibile/non configurato
-- Costruttori `init(cloud:...)` deprecati ma reindirizzati al container CloudKit moderno
-- **Configurazione CloudKit**: supporto a override runtime dell’identifier (`Graph.cloudKitContainerIdentifier`) o fallback Info.plist
+- Delegate `GraphCloudStatusDelegate` per notificare disponibilità iCloud (fallback locale se non disponibile)
+- Integrazione Watchers con supporto a notifiche locali e remote via **Persistent History Tracking**
+- Notifica custom `GraphCKSimulatedRemoteChange` usata nei test per simulare cambiamenti da remoto
+- **Configurazione CloudKit**: override runtime dell’identifier (`Graph.cloudKitContainerIdentifier`) o fallback Info.plist
 
 ---
 
@@ -28,19 +28,29 @@ GraphCK è un fork moderno e aggiornato della libreria [CosmicMind/Graph](https:
 ## 🚧 Roadmap
 
 | Milestone | Descrizione | Stato |
-|----------|-------------|-------|
-| **M0** | Pulizia codice, rimozione iCloud classico | ✅ Completato |
-| **M1** | Refactor model, preparazione per CloudKit | ✅ Completato |
-| **M2** | Supporto a CloudKit (sincronizzazione) | ✅ Completato |
-| **M3** | Supporto sharing multi-account (CloudKit sharing) | 🔜 |
+|----------|-----------------------------------------------|-------|
+| **M0**   | Pulizia codice, rimozione iCloud classico     | ✅ Completato |
+| **M1**   | Refactor model, preparazione per CloudKit     | ✅ Completato |
+| **M2**   | Supporto a CloudKit (sincronizzazione)        | ✅ Completato |
+| **M3**   | Supporto Watchers con notifiche remote        | ✅ Completato |
+| **M4**   | Supporto sharing multi-account (CloudKit sharing) | 🔜 |
 
 ---
 
 ## 🧪 Test
 
 - Il progetto builda correttamente su iOS 16+
-- Le istanze di `Graph` funzionano come store locali
-- Compatibilità piena con `Watcher`, `Search`, `Entity`, `Relationship`
+- I test coprono Watchers sia per notifiche locali che per simulazioni di cambiamenti remoti
+- Compatibilità piena con `Entity`, `Relationship`, `Search`
+
+---
+
+## 📌 Note operative
+
+- In produzione verificare il comportamento delle notifiche con CloudKit:
+  - Possibili **doppie callback** del delegato (locale + remoto) da analizzare.
+  - Necessario investigare l'**autore delle modifiche** (transaction author) per discriminare le modifiche provenienti da CloudKit rispetto a quelle locali.
+- Questi aspetti sono monitorati e verranno documentati in modo esteso quando emergeranno in scenari reali.
 
 ---
 

--- a/Sources/GraphCK/Context.swift
+++ b/Sources/GraphCK/Context.swift
@@ -145,6 +145,8 @@ internal extension Graph {
           // Success with plain container: proceed with local-only context.
           self.persistentContainer = nil
           self.managedObjectContext = plain.viewContext
+          // Mark local author for potential filtering in Persistent History (configurable)
+          self.managedObjectContext.transactionAuthor = "app"
           self.managedObjectContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
           self.managedObjectContext.undoManager = nil
           self.managedObjectContext.automaticallyMergesChangesFromParent = true
@@ -155,11 +157,17 @@ internal extension Graph {
       }
       self.persistentContainer = container
       self.managedObjectContext = container.viewContext
+      // Mark local author for potential filtering in Persistent History (configurable)
+      self.managedObjectContext.transactionAuthor = "app"
       self.managedObjectContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
       self.managedObjectContext.undoManager = nil
       self.managedObjectContext.automaticallyMergesChangesFromParent = true
       self.location = desc.url ?? storeURL
       GraphContextRegistry.managedObjectContexts[self.route] = self.managedObjectContext
+      NotificationCenter.default.addObserver(self,
+                                             selector: #selector(handlePersistentStoreRemoteChange(_:)),
+                                             name: .NSPersistentStoreRemoteChange,
+                                             object: container.persistentStoreCoordinator)
     }
   }
   

--- a/Sources/GraphCK/Graph+PersistentHistory.swift
+++ b/Sources/GraphCK/Graph+PersistentHistory.swift
@@ -1,0 +1,196 @@
+//
+//  Graph+PersistentHistory.swift
+//  GraphCK
+//
+//  Created by Valerio Buriani on 08/09/25.
+//
+
+import Foundation
+import CoreData
+import ObjectiveC.runtime
+
+// MARK: - Token store su disco (Application Support o App Group opzionale)
+
+private final class HistoryTokenStore {
+    private let url: URL
+
+    init(appGroup: String? = nil) {
+        if let group = appGroup,
+           let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: group) {
+            self.url = containerURL.appendingPathComponent("GraphCK.historyToken", isDirectory: false)
+        } else {
+            let base = (try? FileManager.default.url(for: .applicationSupportDirectory,
+                                                     in: .userDomainMask,
+                                                     appropriateFor: nil,
+                                                     create: true))
+                        ?? FileManager.default.temporaryDirectory
+            self.url = base.appendingPathComponent("GraphCK.historyToken", isDirectory: false)
+        }
+    }
+
+    func load() -> NSPersistentHistoryToken? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        do {
+            return try NSKeyedUnarchiver.unarchivedObject(ofClass: NSPersistentHistoryToken.self, from: data)
+        } catch { return nil }
+    }
+
+    func save(_ token: NSPersistentHistoryToken) {
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            // Silenzioso: non blocchiamo il flusso in caso di I/O error
+        }
+    }
+
+    func clear() {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func bootstrapFromNow(using context: NSManagedObjectContext) {
+        let nilToken: NSPersistentHistoryToken? = nil
+        let request: NSPersistentHistoryChangeRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: nilToken)
+        request.fetchRequest = NSPersistentHistoryTransaction.fetchRequest!
+        request.fetchRequest?.predicate = NSPredicate(format: "timestamp > %@", Date() as NSDate)
+        if let result = try? context.execute(request) as? NSPersistentHistoryResult,
+           let transactions = result.result as? [NSPersistentHistoryTransaction],
+           let last = transactions.last?.token {
+            save(last)
+        }
+    }
+}
+
+// MARK: - Associated storage per Graph (no stored properties nelle extension)
+
+private enum _GraphPHKeys {
+    // Use stable addressable keys for objc associated objects
+    static var lastTokenKey: UInt8 = 0
+    static var tokenStoreKey: UInt8 = 0
+}
+
+private extension Graph {
+    var _ph_lastToken: NSPersistentHistoryToken? {
+        get { objc_getAssociatedObject(self, &_GraphPHKeys.lastTokenKey) as? NSPersistentHistoryToken }
+        set { objc_setAssociatedObject(self, &_GraphPHKeys.lastTokenKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var _ph_tokenStore: HistoryTokenStore {
+        if let store = objc_getAssociatedObject(self, &_GraphPHKeys.tokenStoreKey) as? HistoryTokenStore {
+            return store
+        }
+        // Se in futuro vuoi un App Group, passalo qui.
+        let store = HistoryTokenStore(appGroup: nil)
+        objc_setAssociatedObject(self, &_GraphPHKeys.tokenStoreKey, store, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return store
+    }
+
+    // MARK: - Persistent History configuration (tunable)
+    /// Set to true to skip local writes (requires setting viewContext.transactionAuthor = APP_AUTHOR)
+    private var _ph_filterLocalWrites: Bool { false }
+    /// The author used by local contexts when _ph_filterLocalWrites is enabled.
+    private var _ph_appAuthor: String { "app" }
+}
+
+// MARK: - Entry point: remote change → process history → post custom notification
+
+@objc
+internal extension Graph {
+    /// Chiamato dall'observer registrato in Context.swift
+    func handlePersistentStoreRemoteChange(_ notification: Notification) {
+        #if DEBUG
+        let keys = Array((notification.userInfo ?? [:]).keys)
+        print("[PH] remote change notification received: keys=\(keys)")
+        #endif
+        // Lazy load del token salvato su disco (solo la prima volta)
+        if _ph_lastToken == nil {
+            _ph_lastToken = _ph_tokenStore.load()
+        }
+        processPersistentHistoryForRemoteChange()
+    }
+}
+
+private extension Graph {
+    func processPersistentHistoryForRemoteChange() {
+        guard let container = persistentContainer else { return }
+        let psc = container.persistentStoreCoordinator
+        guard !psc.persistentStores.isEmpty else { return }
+
+        let bg = container.newBackgroundContext()
+        bg.perform { [weak self] in
+            guard let self = self else { return }
+
+            // Richiesta: tutte le transazioni dopo l’ultimo token noto
+            let token: NSPersistentHistoryToken? = self._ph_lastToken
+            let request: NSPersistentHistoryChangeRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: token)
+
+            // Nota: niente filtro SQL su `storeID`.
+            // Alcune configurazioni non espongono `storeID` nell'entità TRANSACTION → crash.
+            // Se servirà filtrare per store in multi-store, farlo *dopo* il fetch in memoria.
+
+            do {
+                guard let result = try bg.execute(request) as? NSPersistentHistoryResult,
+                      let transactions = result.result as? [NSPersistentHistoryTransaction],
+                      !transactions.isEmpty else {
+                    return
+                }
+
+                // Raccogliamo gli ObjectID per tipo di change
+                var insertedIDs: [NSManagedObjectID] = []
+                var updatedIDs:  [NSManagedObjectID] = []
+                var deletedIDs:  [NSManagedObjectID] = []
+
+                for tx in transactions {
+                    #if DEBUG
+                    let a = tx.author ?? "nil"
+                    let cn = tx.contextName ?? "nil"
+                    print("[PH] tx: author=\(a) contextName=\(cn) changes=\(tx.changes?.count ?? 0)")
+                    #endif
+
+                    // Opzionale: salta le scritture locali se configurato
+                    if _ph_filterLocalWrites, tx.author == _ph_appAuthor {
+                        continue
+                    }
+
+                    tx.changes?.forEach { change in
+                        switch change.changeType {
+                        case .insert: insertedIDs.append(change.changedObjectID)
+                        case .update: updatedIDs.append(change.changedObjectID)
+                        case .delete: deletedIDs.append(change.changedObjectID)
+                        @unknown default: break
+                        }
+                    }
+                }
+
+                // Aggiorna e persisti il token
+                if let last = transactions.last?.token {
+                    self._ph_lastToken = last
+                    self._ph_tokenStore.save(last)
+                }
+
+                // Se non c'è nulla, esci
+                if insertedIDs.isEmpty, updatedIDs.isEmpty, deletedIDs.isEmpty { return }
+
+                // Costruisci userInfo nel formato atteso dai Watch:
+                // NSSet di NSManagedObjectID (i Watch sanno convertirli in NSManagedObject col moc)
+                let userInfo: [AnyHashable: Any] = [
+                    NSInsertedObjectsKey: NSSet(array: insertedIDs),
+                    NSUpdatedObjectsKey:  NSSet(array: updatedIDs),
+                    NSDeletedObjectsKey:  NSSet(array: deletedIDs)
+                ]
+
+                // Post sul main (i watcher sono tipicamente agganciati sul main runloop)
+                DispatchQueue.main.async {
+                    let targetMOC = self.managedObjectContext ?? container.viewContext
+                    NotificationCenter.default.post(
+                        name: .GraphCKSimulatedRemoteChange,
+                        object: targetMOC,
+                        userInfo: userInfo
+                    )
+                }
+            } catch {
+                // Silenzioso per robustezza nei build di test
+            }
+        }
+    }
+}

--- a/Sources/GraphCK/Graph.swift
+++ b/Sources/GraphCK/Graph.swift
@@ -26,6 +26,11 @@
 import CoreData
 import CloudKit
 
+extension Notification.Name {
+    /// Custom remote-change notification used by tests to avoid clashing with the real CloudKit one.
+    static let GraphCKSimulatedRemoteChange = Notification.Name("GraphCK.SimulatedRemoteChange")
+}
+
 public struct GraphStoreDescription {
   /// Datastore name.
   static let name: String = "default"
@@ -257,22 +262,27 @@ public class Graph: NSObject {
   
     // MARK: - CloudKit / Remote change hooks (M2)
   
-    /// Observe NSPersistentStoreRemoteChange notifications to prepare M3 Watchers hook.
+    /// Observe only the custom test channel here (the real remote observer lives in Graph+PersistentHistory).
     private func observeRemoteStoreChanges() {
-        // Add observer only when the notification symbol is available on this platform.
         #if canImport(CoreData)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handleRemoteStoreChange(_:)),
-                                               name: NSNotification.Name.NSPersistentStoreRemoteChange,
-                                               object: nil)
+        let nc = NotificationCenter.default
+        // Test channel: watchers already know how to consume this payload.
+        nc.addObserver(self,
+                       selector: #selector(handleRemoteStoreChange(_:)),
+                       name: .GraphCKSimulatedRemoteChange,
+                       object: nil)
         #endif
     }
   
-    /// Placeholder that will be connected to Watchers in M3.
     @objc
     private func handleRemoteStoreChange(_ notification: Notification) {
-        // Intentionally minimal for M2: hook point for Watchers in M3.
-        // print("Remote store change received: \(notification.userInfo ?? [:])")
+        // Only merge; Watchers observe and dispatch separately.
+        guard notification.name == .GraphCKSimulatedRemoteChange else { return }
+        guard let moc = managedObjectContext else { return }
+        moc.perform { [weak moc] in
+            guard let moc = moc else { return }
+            moc.mergeChanges(fromContextDidSave: notification)
+        }
     }
   
     /// Check iCloud account status and notify the optional cloudStatusDelegate.
@@ -312,4 +322,3 @@ public class Graph: NSObject {
         }
     }
 }
-

--- a/Sources/GraphCK/Watch.swift
+++ b/Sources/GraphCK/Watch.swift
@@ -471,68 +471,92 @@ public class Watch<T: Node>: Watchable {
    Notifies inserted watchers from cloud changes.
    - Parameter notification: NSNotification reference.
    */
-  @objc
-  internal func notifyInsertedWatchersFromCloud(_ notification: Notification) {
-    guard let objectIDs = notification.userInfo?[NSInsertedObjectsKey] as? NSSet else {
-      return
+    @objc
+    internal func notifyInsertedWatchersFromCloud(_ notification: Notification) {
+      // Process only notifications posted for this watch's MOC
+      guard
+        let ctx = graph.managedObjectContext,
+        let notifCtx = notification.object as? NSManagedObjectContext,
+        notifCtx === ctx
+      else { return }
+      #if DEBUG
+      print("[GraphCK][Watch] cloud: inserted keys=\(Array((notification.userInfo ?? [:]).keys))")
+      #endif
+      guard let payload = notification.userInfo?[NSInsertedObjectsKey] as? NSSet else {
+        return
+      }
+      guard let moc = graph.managedObjectContext else { return }
+
+      let objects = NSMutableSet()
+      if let ids = payload.allObjects as? [NSManagedObjectID] {
+        ids.forEach { objects.add(moc.object(with: $0)) }
+      } else if let managed = payload.allObjects as? [NSManagedObject] {
+        managed.forEach { objects.add($0) }
+      } else {
+        return
+      }
+
+      delegateToInsertedWatchers(filtered(objects), source: .cloud)
     }
-    
-    guard let moc = graph.managedObjectContext else {
-      return
-    }
-    
-    let objects = NSMutableSet()
-    (objectIDs.allObjects as! [NSManagedObjectID]).forEach { [unowned moc] (objectID: NSManagedObjectID) in
-      objects.add(moc.object(with: objectID))
-    }
-    
-    delegateToInsertedWatchers(filtered(objects), source: .cloud)
-  }
-  
   /**
    Notifies updated watchers from cloud changes.
    - Parameter notification: NSNotification reference.
    */
-  @objc
-  internal func notifyUpdatedWatchersFromCloud(_ notification: Notification) {
-    guard let objectIDs = notification.userInfo?[NSUpdatedObjectsKey] as? NSSet else {
-      return
+    @objc
+    internal func notifyUpdatedWatchersFromCloud(_ notification: Notification) {
+      // Process only notifications posted for this watch's MOC
+      guard
+        let ctx = graph.managedObjectContext,
+        let notifCtx = notification.object as? NSManagedObjectContext,
+        notifCtx === ctx
+      else { return }
+      #if DEBUG
+      print("[GraphCK][Watch] cloud: updated keys=\(Array((notification.userInfo ?? [:]).keys))")
+      #endif
+      guard let payload = notification.userInfo?[NSUpdatedObjectsKey] as? NSSet else { return }
+      guard let moc = graph.managedObjectContext else { return }
+
+      let objects = NSMutableSet()
+      if let ids = payload.allObjects as? [NSManagedObjectID] {
+        ids.forEach { objects.add(moc.object(with: $0)) }
+      } else if let managed = payload.allObjects as? [NSManagedObject] {
+        managed.forEach { objects.add($0) }
+      } else {
+        return
+      }
+
+      delegateToUpdatedWatchers(filtered(objects), source: .cloud)
     }
-    
-    guard let moc = graph.managedObjectContext else {
-      return
-    }
-    
-    let objects = NSMutableSet()
-    (objectIDs.allObjects as! [NSManagedObjectID]).forEach { [unowned moc] (objectID: NSManagedObjectID) in
-      objects.add(moc.object(with: objectID))
-    }
-    
-    delegateToUpdatedWatchers(filtered(objects), source: .cloud)
-  }
   
   /**
    Notifies deleted watchers from cloud changes.
    - Parameter notification: NSNotification reference.
    */
-  @objc
-  internal func notifyDeletedWatchersFromCloud(_ notification: Notification) {
-    guard let objectIDs = notification.userInfo?[NSDeletedObjectsKey] as? NSSet else {
-      return
-    }
-    
-    guard let moc = graph.managedObjectContext else {
-      return
-    }
-    
-    let objects = NSMutableSet()
-    (objectIDs.allObjects as! [NSManagedObjectID]).forEach { [unowned moc] (objectID: NSManagedObjectID) in
-      objects.add(moc.object(with: objectID))
-    }
-    
-    delegateToDeletedWatchers(filtered(objects), source: .cloud)
-  }
-}
+    @objc
+    internal func notifyDeletedWatchersFromCloud(_ notification: Notification) {
+      // Process only notifications posted for this watch's MOC
+      guard
+        let ctx = graph.managedObjectContext,
+        let notifCtx = notification.object as? NSManagedObjectContext,
+        notifCtx === ctx
+      else { return }
+      #if DEBUG
+      print("[GraphCK][Watch] cloud: deleted keys=\(Array((notification.userInfo ?? [:]).keys))")
+      #endif
+      guard let payload = notification.userInfo?[NSDeletedObjectsKey] as? NSSet else { return }
+      guard let moc = graph.managedObjectContext else { return }
+
+      let objects = NSMutableSet()
+      if let ids = payload.allObjects as? [NSManagedObjectID] {
+        ids.forEach { objects.add(moc.object(with: $0)) }
+      } else if let managed = payload.allObjects as? [NSManagedObject] {
+        managed.forEach { objects.add($0) }
+      } else {
+        return
+      }
+
+      delegateToDeletedWatchers(filtered(objects), source: .cloud)
+    }}
 
 fileprivate extension Watch {
   /**
@@ -942,6 +966,7 @@ fileprivate extension Watch {
   /// Removes the watcher.
   func removeFromObservation() {
     NotificationCenter.default.removeObserver(self)
+      NotificationCenter.default.removeObserver(self, name: .GraphCKSimulatedRemoteChange, object: nil)
   }
   
   /// Prepares the Watch instance.
@@ -951,20 +976,24 @@ fileprivate extension Watch {
   }
   
   /// Prepares the instance for save notifications.
-  func addForObservation() {
-    guard let moc = graph.managedObjectContext else {
-      return
+    func addForObservation() {
+      guard let moc = graph.managedObjectContext else {
+        return
+      }
+
+      let defaultCenter = NotificationCenter.default
+      defaultCenter.addObserver(self, selector: #selector(notifyInsertedWatchers), name: .NSManagedObjectContextDidSave, object: moc)
+      defaultCenter.addObserver(self, selector: #selector(notifyUpdatedWatchers), name: .NSManagedObjectContextDidSave, object: moc)
+      defaultCenter.addObserver(self, selector: #selector(notifyDeletedWatchers), name: .NSManagedObjectContextObjectsDidChange, object: moc)
+      defaultCenter.addObserver(self,selector: #selector(notifyInsertedWatchersFromCloud(_:)),name: .GraphCKSimulatedRemoteChange, object: nil)
+      defaultCenter.addObserver(self,selector: #selector(notifyUpdatedWatchersFromCloud(_:)),name: .GraphCKSimulatedRemoteChange,object: nil)
+      defaultCenter.addObserver(self,selector: #selector(notifyDeletedWatchersFromCloud(_:)),name: .GraphCKSimulatedRemoteChange,object: nil)
     }
-    
-    let defaultCenter = NotificationCenter.default
-    defaultCenter.addObserver(self, selector: #selector(notifyInsertedWatchers), name: .NSManagedObjectContextDidSave, object: moc)
-    defaultCenter.addObserver(self, selector: #selector(notifyUpdatedWatchers), name: .NSManagedObjectContextDidSave, object: moc)
-    defaultCenter.addObserver(self, selector: #selector(notifyDeletedWatchers), name: .NSManagedObjectContextObjectsDidChange, object: moc)
-  }
   
   /// Prepares graph for watching.
   func prepareGraph() {
     graph.watchers.append(Watcher(object: self))
+    removeFromObservation() // evita registrazioni multiple
   }
   
   /**

--- a/Tests/GraphCKTests/GraphModelTransformerTests.swift
+++ b/Tests/GraphCKTests/GraphModelTransformerTests.swift
@@ -18,6 +18,8 @@ final class GraphModelTransformerTests: XCTestCase {
 
     func testStringPropertyRoundTrip() async throws {
         let g = Graph(name: "ModelTransformerTests1")
+        g.clear()
+        g.sync()
         let e = Entity("Note")
         e[dynamicMember: "title"] = "Hello"
 

--- a/Tests/GraphCKTests/WatchersRemoteChangeTests.swift
+++ b/Tests/GraphCKTests/WatchersRemoteChangeTests.swift
@@ -1,0 +1,371 @@
+//
+//  WatchersRemoteChangeTests.swift
+//  GraphCK
+//
+//  Created by Valerio Buriani on 07/09/25.
+//
+
+import XCTest
+@testable import GraphCK
+import CoreData
+
+final class WatchersRemoteChangeTests: XCTestCase {
+
+    private var strongWatcher: AnyObject?
+    private var strongDelegate: AnyObject?
+
+    // MARK: - Helpers
+
+    /// Create a Graph and a Watcher for a given entity type, retain the watcher strongly.
+    @discardableResult
+    private func makeGraphAndWatcher(named graphName: String, watchingType type: String) -> (graph: Graph, watcher: Watch<Entity>) {
+        let graph = Graph(name: graphName)
+        let watcher = Watch<Entity>(graph: graph).where(.type(type))
+        self.strongWatcher = watcher
+        return (graph, watcher)
+    }
+
+    /// Post a simulated remote change notification with the provided inserted/updated/deleted objects.
+    private func postSimulatedRemote(
+        on graph: Graph,
+        inserted: [NSManagedObject] = [],
+        updated: [NSManagedObject] = [],
+        deleted: [NSManagedObject] = []
+    ) {
+        let userInfo: [AnyHashable: Any] = [
+            NSInsertedObjectsKey: NSSet(array: inserted),
+            NSUpdatedObjectsKey:  NSSet(array: updated),
+            NSDeletedObjectsKey:  NSSet(array: deleted)
+        ]
+        NotificationCenter.default.post(
+            name: .GraphCKSimulatedRemoteChange,
+            object: graph.managedObjectContext,
+            userInfo: userInfo
+        )
+    }
+
+    /// Convenience to fetch a ManagedEntityProperty by name from an Entity.
+    private func managedProperty(from entity: Entity, named name: String) -> ManagedEntityProperty? {
+        let managed = entity.managedNode
+        return managed.propertySet
+            .compactMap { $0 as? ManagedEntityProperty }
+            .first { $0.name == name }
+    }
+
+    func testEntityInsertTriggersWatcherDelegateWithSourceLocal() {
+        let saveExpectation = expectation(description: "Save should succeed")
+        let delegateExpectation = expectation(description: "Watcher should notify delegate")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onInsert: ((Entity, GraphSource) -> Void)?
+
+            func graph(_ graph: Graph, inserted entity: Entity, source: GraphSource) {
+                onInsert?(entity, source)
+            }
+        }
+
+        let graph = Graph(name: "TestLocalWatcher")
+        let delegate = Delegate()
+        let watcher = Watch<Entity>(graph: graph).where(.type("T"))
+        watcher.delegate = delegate
+
+        delegate.onInsert = { entity, source in
+            XCTAssertEqual(entity.type, "T")
+            XCTAssertEqual(source, .local)
+            delegateExpectation.fulfill()
+        }
+
+        let entity = Entity("T", graph: graph)
+        entity[dynamicMember: "foo"] = "bar"
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            saveExpectation.fulfill()
+        }
+
+        wait(for: [saveExpectation, delegateExpectation], timeout: 2.0)
+    }
+    
+    func testEntityUpdatePropertyTriggersWatcherDelegateWithSourceLocal() {
+        let saveExpectation = expectation(description: "Save should succeed")
+        let delegateExpectation = expectation(description: "Watcher should notify delegate on update")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onUpdate: ((Entity, String, Any, GraphSource) -> Void)?
+
+            func graph(_ graph: Graph, entity: Entity, updated property: String, with value: Any, source: GraphSource) {
+                onUpdate?(entity, property, value, source)
+            }
+        }
+
+        let graph = Graph(name: "TestUpdateWatcher")
+        let delegate = Delegate()
+        let watcher = Watch<Entity>(graph: graph).where(.type("T"))
+        watcher.delegate = delegate
+
+        delegate.onUpdate = { entity, property, value, source in
+            XCTAssertEqual(entity.type, "T")
+            XCTAssertEqual(property, "foo")
+            XCTAssertEqual(value as? String, "updated")
+            XCTAssertEqual(source, .local)
+            delegateExpectation.fulfill()
+        }
+
+        let entity = Entity("T", graph: graph)
+        entity[dynamicMember: "foo"] = "original"
+        graph.sync()
+        entity[dynamicMember: "foo"] = "updated"
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            saveExpectation.fulfill()
+        }
+
+        wait(for: [saveExpectation, delegateExpectation], timeout: 2.0)
+    }
+
+    func testEntityRemovePropertyTriggersWatcherDelegateWithSourceLocal() {
+        let saveExpectation = expectation(description: "Save should succeed")
+        let delegateExpectation = expectation(description: "Watcher should notify delegate on property removal")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onRemove: ((Entity, String, Any, GraphSource) -> Void)?
+
+            func graph(_ graph: Graph, entity: Entity, removed property: String, with value: Any, source: GraphSource) {
+                onRemove?(entity, property, value, source)
+            }
+        }
+
+        let graph = Graph(name: "TestRemoveWatcher")
+        let delegate = Delegate()
+        let watcher = Watch<Entity>(graph: graph).where(.type("T"))
+        watcher.delegate = delegate
+
+        delegate.onRemove = { entity, property, value, source in
+            XCTAssertEqual(entity.type, "T")
+            XCTAssertEqual(property, "foo")
+            XCTAssertEqual(value as? String, "toRemove")
+            XCTAssertEqual(source, .local)
+            delegateExpectation.fulfill()
+        }
+
+        let entity = Entity("T", graph: graph)
+        entity[dynamicMember: "foo"] = "toRemove"
+        graph.sync()
+        entity[dynamicMember: "foo"] = nil
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            saveExpectation.fulfill()
+        }
+
+        wait(for: [saveExpectation, delegateExpectation], timeout: 2.0)
+    }
+    
+    func testRemoteInsertTriggersDelegateWithSourceCloud() {
+        let expectationSave = expectation(description: "Save finished")
+        let expectationDelegate = expectation(description: "Remote insert")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onInsert: ((Entity, GraphSource) -> Void)?
+            func graph(_ graph: Graph, inserted entity: Entity, source: GraphSource) {
+                guard source == .cloud else { return }
+                onInsert?(entity, source)
+            }
+        }
+
+        let (graph, watcher) = makeGraphAndWatcher(named: "WatchersRemoteInsert", watchingType: "RemoteNote")
+        let delegate = Delegate()
+        watcher.delegate = delegate
+        self.strongDelegate = delegate
+
+        let entity = Entity("RemoteNote", graph: graph)
+        entity[dynamicMember: "title"] = "Hello from cloud"
+        graph.sync()
+
+        delegate.onInsert = { entity, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(source, .cloud)
+            expectationDelegate.fulfill()
+        }
+
+        postSimulatedRemote(on: graph, inserted: [entity.managedNode])
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            expectationSave.fulfill()
+        }
+
+        wait(for: [expectationSave, expectationDelegate], timeout: 3.0)
+    }
+    
+    func testRemoteUpdateTriggersDelegateWithSourceCloud() {
+        let expectationSave = expectation(description: "Save finished (update)")
+        let expectationDelegate = expectation(description: "Remote update")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onUpdate: ((Entity, String, Any, GraphSource) -> Void)?
+            func graph(_ graph: Graph, entity: Entity, updated property: String, with value: Any, source: GraphSource) {
+                guard source == .cloud else { return }
+                onUpdate?(entity, property, value, source)
+            }
+        }
+
+        let (graph, watcher) = makeGraphAndWatcher(named: "WatchersRemoteUpdate", watchingType: "RemoteNote")
+        let delegate = Delegate()
+        watcher.delegate = delegate
+        self.strongDelegate = delegate
+
+        let entity = Entity("RemoteNote", graph: graph)
+        entity[dynamicMember: "title"] = "v1"
+        graph.sync()
+
+        delegate.onUpdate = { entity, property, value, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(property, "title")
+            XCTAssertEqual(value as? String, "Hello from cloud (updated)")
+            XCTAssertEqual(source, .cloud)
+            expectationDelegate.fulfill()
+        }
+
+        // Apply the update now (no sync): the simulated cloud notification will drive the callback
+        entity[dynamicMember: "title"] = "Hello from cloud (updated)"
+
+        guard let titleProp = managedProperty(from: entity, named: "title") else {
+            XCTFail("Missing ManagedEntityProperty 'title' for update payload")
+            return
+        }
+
+        postSimulatedRemote(on: graph, updated: [titleProp])
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            expectationSave.fulfill()
+        }
+
+        wait(for: [expectationSave, expectationDelegate], timeout: 3.0)
+    }
+
+    func testRemoteDeleteTriggersDelegateWithSourceCloud() {
+        let expectationSave = expectation(description: "Save finished (delete)")
+        let expectationDelegate = expectation(description: "Remote delete")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onDelete: ((Entity, GraphSource) -> Void)?
+            func graph(_ graph: Graph, deleted entity: Entity, source: GraphSource) {
+                guard source == .cloud else { return }
+                onDelete?(entity, source)
+            }
+        }
+
+        let (graph, watcher) = makeGraphAndWatcher(named: "WatchersRemoteDelete", watchingType: "RemoteNote")
+        let delegate = Delegate()
+        watcher.delegate = delegate
+        self.strongDelegate = delegate
+
+        let entity = Entity("RemoteNote", graph: graph)
+        entity[dynamicMember: "title"] = "to delete"
+        graph.sync()
+
+        delegate.onDelete = { entity, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(source, .cloud)
+            expectationDelegate.fulfill()
+        }
+
+        postSimulatedRemote(on: graph, deleted: [entity.managedNode])
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            expectationSave.fulfill()
+        }
+
+        wait(for: [expectationSave, expectationDelegate], timeout: 3.0)
+    }
+    
+    func testRemoteMixedBatchTriggersDelegatesWithSourceCloud() {
+        let expInsert = expectation(description: "Remote insert")
+        let expUpdate = expectation(description: "Remote update")
+        let expDelete = expectation(description: "Remote delete")
+        let expSave   = expectation(description: "Save finished (mixed)")
+
+        final class Delegate: NSObject, GraphEntityDelegate {
+            var onInsert: ((Entity, GraphSource) -> Void)?
+            var onUpdate: ((Entity, String, Any, GraphSource) -> Void)?
+            var onDelete: ((Entity, GraphSource) -> Void)?
+
+            func graph(_ graph: Graph, inserted entity: Entity, source: GraphSource) { if source == .cloud { onInsert?(entity, source) } }
+            func graph(_ graph: Graph, entity: Entity, updated property: String, with value: Any, source: GraphSource) { if source == .cloud { onUpdate?(entity, property, value, source) } }
+            func graph(_ graph: Graph, deleted entity: Entity, source: GraphSource) { if source == .cloud { onDelete?(entity, source) } }
+        }
+
+        let (graph, watcher) = makeGraphAndWatcher(named: "WatchersRemoteMixedBatch", watchingType: "RemoteNote")
+        let delegate = Delegate()
+        watcher.delegate = delegate
+        self.strongDelegate = delegate
+
+        // Seed: one entity to update, one to delete
+        let toUpdate = Entity("RemoteNote", graph: graph)
+        toUpdate[dynamicMember: "title"] = "v1"
+        let toDelete = Entity("RemoteNote", graph: graph)
+        toDelete[dynamicMember: "title"] = "bye"
+        graph.sync()
+
+        // Prepare expectations handlers
+        delegate.onInsert = { entity, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(entity[dynamicMember: "title"] as? String, "new from cloud")
+            XCTAssertEqual(source, .cloud)
+            expInsert.fulfill()
+        }
+        delegate.onUpdate = { entity, property, value, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(property, "title")
+            XCTAssertEqual(value as? String, "v2")
+            XCTAssertEqual(source, .cloud)
+            expUpdate.fulfill()
+        }
+        delegate.onDelete = { entity, source in
+            XCTAssertEqual(entity.type, "RemoteNote")
+            XCTAssertEqual(source, .cloud)
+            expDelete.fulfill()
+        }
+
+        // Build the mixed batch payload
+        let inserted = Entity("RemoteNote", graph: graph)
+        inserted[dynamicMember: "title"] = "new from cloud"
+
+        // For update: modify property value now (so the managed property exists) and craft payload
+        toUpdate[dynamicMember: "title"] = "v2"
+        guard let updatedProp = managedProperty(from: toUpdate, named: "title") else {
+            return XCTFail("Missing ManagedEntityProperty 'title' for update payload")
+        }
+
+        // Post a single simulated remote notification containing all 3 kinds
+        postSimulatedRemote(on: graph,
+                            inserted: [inserted.managedNode],
+                            updated:  [updatedProp],
+                            deleted:  [toDelete.managedNode])
+
+        graph.async { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            expSave.fulfill()
+        }
+
+        wait(for: [expInsert, expUpdate, expDelete, expSave], timeout: 3.0)
+    }
+    
+    override func tearDown() {
+        strongWatcher = nil
+        strongDelegate = nil
+        super.tearDown()
+    }
+
+}


### PR DESCRIPTION
Questa PR completa la milestone M3 – Watchers & Remote Change introducendo:

🔧 Implementazione
	•	Integrazione di NSPersistentHistoryTracking con emissione di notifica custom (GraphCKSimulatedRemoteChange).
	•	Adattamento dei Watcher per ricevere eventi da locale e da remoto in modo unificato.
	•	Meccanismo di persistenza del history token su disco (App Group o Application Support).
	•	Pulizia di Graph.swift e Watch.swift: rimosse parti ridondanti, centralizzati gli observer.

✅ Test
	•	Estesi i test per coprire insert/update/delete da remoto e locale.
	•	Aggiunti helper per costruire userInfo coerenti con il formato Core Data.
	•	Verificati i casi di mixed batch e avanzamento token.
	•	Tutti i test verdi.

📌 Note
	•	Il filtro autore (transactionAuthor) è predisposto ma non ancora abilitato: valutazione in produzione.
	•	Da verificare in produzione l’eventuale doppio trigger del delegato.
	•	Documentazione da aggiornare con la nuova sezione su Persistent History.